### PR TITLE
Add Home Assistant Supervisor add-on support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ Once the registry image is published, pin it in `compose.yaml`:
 image: ghcr.io/loryanstrant/esphome-mcp:latest
 ```
 
+## Run as a Home Assistant App
+
+Prefer to run it as a Home Assistant Supervisor add-on — shown in the UI as an
+"App" since Home Assistant 2026.2 — with a sidebar status page and no manual
+env-var setup? Add `https://github.com/loryanstrant/esphome-mcp` as a
+repository (**Settings → Apps → Install app → ⋮ → Repositories**), install
+**ESPHome MCP**, and configure it entirely from its **Configuration** tab — no
+YAML editing. See [`ha_addon/esphome-mcp/DOCS.md`](ha_addon/esphome-mcp/DOCS.md)
+for full setup and how to connect an MCP client (it secures the endpoint with a
+per-install secret path instead of a fixed `/mcp`).
+
 ## Connect an MCP client
 
 Point your client at the Streamable HTTP endpoint:
@@ -84,6 +95,11 @@ make check         # lint + format-check + typecheck + test
 # live tests against a real 2026.6 dashboard:
 ESPHOME_DASHBOARD_URL=https://esphome.example.com .venv/bin/pytest -m live
 ```
+
+**Releasing:** the release workflow builds and pushes the multi-arch image the
+add-on points at, but doesn't touch the add-on manifest — bump `version` in
+[`ha_addon/esphome-mcp/config.yaml`](ha_addon/esphome-mcp/config.yaml) to match
+the new tag before pushing it, so Supervisor's update check picks it up.
 
 ## Credits
 

--- a/ha_addon/esphome-mcp/CHANGELOG.md
+++ b/ha_addon/esphome-mcp/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2026-08-13
+
+- Initial Home Assistant add-on release: reuses the existing multi-arch image,
+  adds an ingress status/connect-instructions page, and secures the MCP endpoint
+  behind a persisted, high-entropy secret path instead of a fixed `/mcp`.

--- a/ha_addon/esphome-mcp/DOCS.md
+++ b/ha_addon/esphome-mcp/DOCS.md
@@ -1,0 +1,83 @@
+# ESPHome MCP — Home Assistant Add-on
+
+An [MCP](https://modelcontextprotocol.io) server for the ESPHome 2026.6+ "Device
+Builder" dashboard, packaged as a Home Assistant Supervisor add-on. See the
+[main README](https://github.com/loryanstrant/esphome-mcp) for what the server can
+do.
+
+## Installation
+
+1. In Home Assistant, go to **Settings → Apps → Install app**, then use the
+   **⋮ → Repositories** menu in the top-right corner to add:
+
+   ```
+   https://github.com/loryanstrant/esphome-mcp
+   ```
+
+   (Home Assistant renamed "Add-ons" to "Apps" in the UI as of 2026.2 — this is
+   still a Supervisor add-on under the hood, just presented under the Apps
+   section now.)
+
+2. Install **ESPHome MCP** from the app store.
+3. `dashboard_url` already defaults to `http://homeassistant.local:6052` — correct
+   out of the box if you're running the official **ESPHome Device Builder**
+   app on this same Home Assistant host (the common case). Open the
+   **Configuration** tab only if that's wrong for your setup, or your dashboard
+   needs `dashboard_username`/`dashboard_password`. Everything is configured
+   through this tab — no YAML editing needed.
+4. Start the app.
+
+## Connecting an MCP client
+
+The ingress status page has no fixed URL — Home Assistant generates a random,
+per-install token for it (`/api/hassio_ingress/<token>/...`) and only exposes it
+through an authenticated session, so it can't be linked to directly. To reach it:
+open this app's page (**Settings → Apps → ESPHome MCP**), go to its **Info**
+tab, and click **Open Web UI**. That page shows dashboard connectivity and the
+exact connect URL to give your MCP client, including the live port and secret
+path, e.g.:
+
+```
+http://<your-home-assistant-ip-or-hostname>:8080/private_<random-token>
+```
+
+Replace `<your-home-assistant-ip-or-hostname>` with the address you use to reach
+Home Assistant itself (same host, *without* the `:8123` — this add-on listens on
+its own port, separate from the main HA web UI). The `8080` above is the default;
+if you've remapped the add-on's port in its **Network** section, use that port
+instead — the ingress panel always reflects the current value.
+
+The path after the port (`/private_<random-token>`) is a high-entropy secret
+generated on first start and persisted across restarts — it's the credential that
+protects the endpoint, so treat the full URL like a password. It's also logged
+once at startup (**Log** tab) if you need it without opening the status page. To
+pin a specific value instead of the generated one, set the `secret_path` option
+in the Configuration tab.
+
+**To rotate it** (e.g. you suspect it leaked): turn on `regenerate_secret_path`
+in the Configuration tab and restart the add-on. A fresh secret is generated,
+the option is automatically switched back off so it won't regenerate again on
+every subsequent restart, and any MCP client using the old URL will need the
+new one from the status page or logs.
+
+## Options
+
+| Option | Required | Description |
+| --- | --- | --- |
+| `dashboard_url` | yes | Your ESPHome dashboard's base URL. Defaults to `http://homeassistant.local:6052` (correct for the common co-located setup) — change it if your dashboard runs elsewhere. |
+| `dashboard_username` | no | Basic Auth user, only if the dashboard requires it. |
+| `dashboard_password` | no | Basic Auth password. |
+| `log_level` | no | `debug` / `info` / `warning` / `error` (default `info`). |
+| `secret_path` | no | Pin the MCP endpoint's path instead of using the auto-generated one. Must start with `/` and be at least 8 characters. |
+| `regenerate_secret_path` | no | Set `true` and restart to force a fresh secret path; automatically resets to `false` afterward. |
+
+## Changing the port
+
+The app listens on port `8080` by default. If that collides with something
+else on your host, remap it in its **Info → Network** section — no YAML editing
+required. The ingress status page always shows the port actually in use.
+
+## Uninstalling
+
+Stop and remove the app from the App Store as usual. Its persisted secret path
+is stored under its own `/data` and is removed along with it.

--- a/ha_addon/esphome-mcp/config.yaml
+++ b/ha_addon/esphome-mcp/config.yaml
@@ -1,0 +1,50 @@
+name: "ESPHome MCP"
+description: "MCP server for the ESPHome 2026.6+ Device Builder dashboard"
+version: "2026.06.0"
+slug: "esphome-mcp"
+url: "https://github.com/loryanstrant/esphome-mcp"
+arch:
+  - amd64
+  - aarch64
+startup: services
+boot: auto
+# Read-only Supervisor self-info lookup, used for the status page's port and to
+# reset regenerate_secret_path back to false after honoring it. Both are
+# /addons/self/* endpoints.
+hassio_api: true
+# Reuses the same multi-arch image CI already publishes on release.
+image: "ghcr.io/loryanstrant/esphome-mcp"
+# The status/instructions page (dashboard connectivity + MCP connect URL).
+# The MCP endpoint itself is NOT served over ingress -- ingress requires an
+# authenticated HA session, which MCP clients can't do. See ports below.
+ingress: true
+ingress_port: 8080
+panel_icon: mdi:chip
+ports:
+  8080/tcp: 8080
+ports_description:
+  8080/tcp: "MCP Streamable HTTP endpoint for MCP clients (Claude, etc.)"
+options:
+  # Correct out of the box for the common case: ESPHome Device Builder
+  # co-located on this same HA host. There's no way to detect this for real
+  # (Supervisor's discovery API is Home Assistant Core-only, not usable by
+  # other add-ons) -- this is a default guess, not auto-discovery. Change it
+  # if your dashboard runs elsewhere.
+  dashboard_url: "http://homeassistant.local:6052"
+  dashboard_username: ""
+  dashboard_password: ""
+  log_level: "info"
+  secret_path: ""
+  regenerate_secret_path: false
+schema:
+  # Plain str?, not url? -- Supervisor's "url" format rejects an empty string
+  # even as optional. The default below is non-empty, but a user can still
+  # clear the field to "", so url? would reintroduce the same save failure.
+  # The app itself validates it properly at connect time and retries/exits
+  # with a clear error if it's unset/invalid.
+  dashboard_url: "str?"
+  dashboard_username: "str?"
+  dashboard_password: "password?"
+  log_level: "list(debug|info|warning|error)"
+  secret_path: "str?"
+  regenerate_secret_path: "bool?"

--- a/ha_addon/esphome-mcp/translations/en.yaml
+++ b/ha_addon/esphome-mcp/translations/en.yaml
@@ -1,0 +1,33 @@
+configuration:
+  dashboard_url:
+    name: "ESPHome dashboard URL"
+    description: >-
+      Base URL of your ESPHome Device Builder dashboard. Defaults to the
+      common setup where it runs on this same Home Assistant host
+      (http://homeassistant.local:6052) -- change this if yours runs
+      elsewhere.
+  dashboard_username:
+    name: "Dashboard username (optional)"
+    description: >-
+      Only needed if your ESPHome dashboard has Basic Auth enabled. Leave
+      blank otherwise -- most installs don't need this.
+  dashboard_password:
+    name: "Dashboard password (optional)"
+    description: >-
+      Only needed if your ESPHome dashboard has Basic Auth enabled. Leave
+      blank otherwise -- most installs don't need this.
+  log_level:
+    name: "Log level"
+    description: "Verbosity of this add-on's own logs."
+  secret_path:
+    name: "Secret path override (optional)"
+    description: >-
+      Pin the MCP endpoint's URL path instead of using the auto-generated,
+      high-entropy one. Must start with / and be at least 8 characters.
+      Leave blank to let the add-on generate and persist one for you.
+  regenerate_secret_path:
+    name: "Regenerate secret path"
+    description: >-
+      Turn on and restart to force a fresh secret path (e.g. if the old one
+      leaked). Automatically switches back off afterward, so it won't
+      regenerate again on every restart.

--- a/healthcheck.py
+++ b/healthcheck.py
@@ -8,11 +8,20 @@ tool works — unlike a bare TCP/HTTP probe.
 """
 
 import json
+import os
 import sys
 
 import httpx
 
-URL = "http://localhost:8080/mcp"
+
+def _mcp_url() -> str:
+    """The MCP endpoint URL, honoring MCP_PATH (set by the HA add-on to a
+    per-install secret path). Defaults to /mcp, matching plain Docker usage."""
+    path = os.environ.get("MCP_PATH", "/mcp")
+    return f"http://localhost:8080{path}"
+
+
+URL = _mcp_url()
 HEADERS = {
     "Accept": "application/json, text/event-stream",
     "Content-Type": "application/json",

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: ESPHome MCP
+url: "https://github.com/loryanstrant/esphome-mcp"
+maintainer: "loryanstrant"

--- a/src/esphome_mcp/__main__.py
+++ b/src/esphome_mcp/__main__.py
@@ -1,8 +1,10 @@
 import asyncio
 import logging
 import os
+import threading
 import time
 
+from esphome_mcp import addon
 from esphome_mcp.client import get_client
 from esphome_mcp.server import mcp
 
@@ -15,16 +17,27 @@ logger = logging.getLogger(__name__)
 
 
 def _configure_logging() -> None:
-    level = os.environ.get("LOG_LEVEL", "INFO").upper()
-    logging.basicConfig(format=LOG_FORMAT, level=getattr(logging, level, logging.INFO))
+    """Idempotent: safe to call again after LOG_LEVEL changes (e.g. once options
+    are merged from a Home Assistant add-on's /data/options.json), unlike a bare
+    ``logging.basicConfig()`` call, which is a no-op once handlers exist."""
+    level = getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper(), logging.INFO)
+    logging.basicConfig(format=LOG_FORMAT, level=level)
+    logging.root.setLevel(level)
 
 
-def _check_connectivity() -> None:
+def _check_connectivity(fatal: bool = True) -> None:
     """Verify connectivity to the ESPHome dashboard, retrying on failure.
 
     Uses the cheap REST ``/version`` endpoint so the pre-flight check does not open
     (and leave dangling) a WebSocket on a throwaway event loop — the persistent WS
     connection is established lazily within the server's own loop on first tool call.
+
+    With ``fatal=True`` (stdio, via ``main()``), exhausting retries raises
+    ``SystemExit(1)`` -- there's no other way for that transport to signal trouble.
+    With ``fatal=False`` (HTTP, via ``main_web()``), it logs and returns instead:
+    the HTTP server needs to come up regardless, so the add-on's ingress status
+    page (and the Docker ``HEALTHCHECK``) can report the dashboard as unreachable
+    rather than nothing being reachable at all.
     """
     for attempt in range(1, _MAX_RETRIES + 1):
         try:
@@ -41,7 +54,25 @@ def _check_connectivity() -> None:
             if attempt < _MAX_RETRIES:
                 logger.info("Retrying in %d seconds...", _RETRY_DELAY)
                 time.sleep(_RETRY_DELAY)
-    raise SystemExit(1)
+    if fatal:
+        raise SystemExit(1)
+    logger.error(
+        "Starting anyway -- check the status page or dashboard_url and restart "
+        "once the dashboard is reachable."
+    )
+
+
+def _check_connectivity_background() -> None:
+    """Run the (non-fatal) connectivity pre-flight check in a background thread.
+
+    ``mcp.run()`` blocks forever once called, so running the check inline before
+    it -- even non-fatally -- would still delay the HTTP server (and the add-on's
+    ingress status page) coming up for the whole retry window. A background
+    thread lets ``mcp.run()`` start immediately while the check keeps logging its
+    own progress; it uses the cheap REST endpoint (see ``_check_connectivity``),
+    not the WebSocket the server's own event loop manages, so the two don't race.
+    """
+    threading.Thread(target=_check_connectivity, kwargs={"fatal": False}, daemon=True).start()
 
 
 def main() -> None:
@@ -51,9 +82,15 @@ def main() -> None:
 
 
 def main_web() -> None:
+    # Logging must be configured *before* resolve_mcp_path(), or anything it logs
+    # (options merge, secret-path resolution) is silently dropped -- Python's
+    # no-handler-yet fallback only surfaces WARNING+, unformatted. Reconfigured
+    # again afterward in case options set LOG_LEVEL.
     _configure_logging()
-    _check_connectivity()
-    mcp.run(transport="http", host="0.0.0.0", port=8080)
+    mcp_path = addon.resolve_mcp_path()
+    _configure_logging()
+    _check_connectivity_background()
+    mcp.run(transport="http", host="0.0.0.0", port=8080, path=mcp_path)
 
 
 if __name__ == "__main__":

--- a/src/esphome_mcp/addon.py
+++ b/src/esphome_mcp/addon.py
@@ -1,0 +1,157 @@
+"""Home Assistant Supervisor add-on integration.
+
+Translates Supervisor's ``/data/options.json`` into the environment variables the
+rest of the app already reads, and manages the persisted, high-entropy path used to
+mount the MCP endpoint (instead of a fixed, guessable ``/mcp``) when running as the
+add-on. Every entry point here is a no-op when ``/data/options.json`` is absent, so
+plain Docker/``docker compose`` usage is unaffected.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import secrets
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path("/data")
+OPTIONS_PATH = DATA_DIR / "options.json"
+SECRET_PATH_FILE = DATA_DIR / "secret_path.txt"
+
+_SUPERVISOR_SELF_OPTIONS_URL = "http://supervisor/addons/self/options"
+
+_OPTION_ENV_MAP = {
+    "dashboard_url": "ESPHOME_DASHBOARD_URL",
+    "dashboard_username": "ESPHOME_DASHBOARD_USERNAME",
+    "dashboard_password": "ESPHOME_DASHBOARD_PASSWORD",
+    "log_level": "LOG_LEVEL",
+}
+
+# Same shape as the add-on secret path convention this follows: leading slash, no
+# embedded scheme, at least 8 characters so a stray "/x" typo can't produce a
+# trivially guessable mount point.
+_SECRET_PATH_RE = re.compile(r"^/(?!.*://)\S{7,}$")
+
+
+def load_addon_options(options_path: Path = OPTIONS_PATH) -> dict[str, object]:
+    """Load Supervisor's options file, or ``{}`` if absent or unparseable."""
+    if not options_path.exists():
+        return {}
+    try:
+        return json.loads(options_path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Failed to read add-on options (%s): %s", options_path, e)
+        return {}
+
+
+def apply_addon_options_to_env(options: dict[str, object]) -> None:
+    """Set env vars from add-on options, without overriding ones already set."""
+    for key, env_var in _OPTION_ENV_MAP.items():
+        value = options.get(key)
+        if value and env_var not in os.environ:
+            os.environ[env_var] = str(value)
+
+
+def _generate_secret_path() -> str:
+    return "/private_" + secrets.token_urlsafe(16)
+
+
+def _is_valid_secret_path(path: str) -> bool:
+    return bool(_SECRET_PATH_RE.match(path))
+
+
+def _persist_secret_path(secret_file: Path, path: str) -> None:
+    secret_file.parent.mkdir(parents=True, exist_ok=True)
+    secret_file.write_text(path)
+
+
+def _reset_regenerate_flag(options: dict[str, object], client: httpx.Client | None = None) -> None:
+    """Best-effort: flip ``regenerate_secret_path`` back to False in Supervisor's
+    stored options after honoring it, so it doesn't regenerate again on every
+    subsequent restart. Any failure is logged and swallowed — the add-on keeps
+    running with the new secret path either way; the user just has to toggle the
+    option back off manually in the Configuration tab if this write fails.
+    """
+    token = os.environ.get("SUPERVISOR_TOKEN")
+    if not token:
+        return
+    owns_client = client is None
+    if client is None:
+        client = httpx.Client(timeout=5)
+    try:
+        resp = client.post(
+            _SUPERVISOR_SELF_OPTIONS_URL,
+            json={"options": {**options, "regenerate_secret_path": False}},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        resp.raise_for_status()
+    except Exception as e:
+        logger.warning(
+            "Could not reset regenerate_secret_path after regenerating (%s). "
+            "Toggle it off manually in the Configuration tab, or it will "
+            "regenerate again on the next restart.",
+            e,
+        )
+    finally:
+        if owns_client:
+            client.close()
+
+
+def get_or_create_secret_path(
+    options: dict[str, object], secret_file: Path = SECRET_PATH_FILE
+) -> str:
+    """Resolve the MCP mount path: a valid option override, else (unless
+    ``regenerate_secret_path`` is set) the persisted path, else a freshly
+    generated one (persisted for reuse on restart)."""
+    override = options.get("secret_path")
+    if isinstance(override, str) and override.strip():
+        path = override.strip()
+        if not path.startswith("/"):
+            path = "/" + path
+        if _is_valid_secret_path(path):
+            _persist_secret_path(secret_file, path)
+            return path
+        logger.warning("Configured secret_path %r is invalid; ignoring.", path)
+
+    force_regenerate = bool(options.get("regenerate_secret_path"))
+    if not force_regenerate and secret_file.exists():
+        stored = secret_file.read_text().strip()
+        if _is_valid_secret_path(stored):
+            return stored
+        logger.warning("Stored secret path %r is invalid; regenerating.", stored)
+
+    new_path = _generate_secret_path()
+    _persist_secret_path(secret_file, new_path)
+    if force_regenerate:
+        logger.info("MCP secret path regenerated (regenerate_secret_path was set).")
+        _reset_regenerate_flag(options)
+    return new_path
+
+
+def resolve_mcp_path(
+    options_path: Path = OPTIONS_PATH, secret_file: Path = SECRET_PATH_FILE
+) -> str:
+    """Merge add-on options into the environment and return the MCP mount path.
+
+    Outside the add-on (no options file), this just returns ``MCP_PATH`` from the
+    environment, defaulting to ``/mcp`` — the existing behavior. An explicit
+    ``MCP_PATH`` always wins over a generated secret path.
+    """
+    options = load_addon_options(options_path)
+    if options:
+        apply_addon_options_to_env(options)
+        if "MCP_PATH" not in os.environ:
+            secret_path = get_or_create_secret_path(options, secret_file)
+            os.environ["MCP_PATH"] = secret_path
+            logger.info(
+                "MCP endpoint mounted at %s (the full connect URL, including port, "
+                "is shown on this add-on's ingress status page)",
+                secret_path,
+            )
+    return os.environ.get("MCP_PATH", "/mcp")

--- a/src/esphome_mcp/server.py
+++ b/src/esphome_mcp/server.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
+import os
+from html import escape
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+import httpx
 from fastmcp import FastMCP
+from starlette.responses import HTMLResponse, Response
 
 from esphome_mcp.client import fetch_schema, get_client, validate_local_configuration
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +78,87 @@ mcp = FastMCP(
     name="ESPHome MCP",
     instructions=INSTRUCTIONS,
 )
+
+DEFAULT_PORT = 8080
+_SUPERVISOR_ADDON_INFO_URL = "http://supervisor/addons/self/info"
+_STATUS_CHECK_TIMEOUT = 5.0
+
+
+async def _resolve_host_port(client: httpx.AsyncClient | None = None) -> int:
+    """Ask Supervisor for the current host-side port mapped to 8080/tcp.
+
+    Reflects a remap made in the add-on's Network tab. Falls back to
+    ``DEFAULT_PORT`` when not running as the add-on (no ``SUPERVISOR_TOKEN``) or
+    when the Supervisor API call fails for any reason — the status page still
+    renders, just with a possibly-stale port number.
+    """
+    token = os.environ.get("SUPERVISOR_TOKEN")
+    if not token:
+        return DEFAULT_PORT
+
+    owns_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(timeout=5)
+    try:
+        resp = await client.get(
+            _SUPERVISOR_ADDON_INFO_URL, headers={"Authorization": f"Bearer {token}"}
+        )
+        resp.raise_for_status()
+        mapped = resp.json().get("data", {}).get("network", {}).get("8080/tcp")
+        if isinstance(mapped, int):
+            return mapped
+    except Exception as e:
+        logger.warning("Could not resolve add-on host port from Supervisor: %s", e)
+    finally:
+        if owns_client:
+            await client.aclose()
+    return DEFAULT_PORT
+
+
+async def _check_dashboard_status() -> str:
+    """Quick, bounded connectivity check for the status page.
+
+    Independent of the app's general 30s HTTP timeout (used for real
+    operations) -- this page's whole job is a fast diagnostic glance, so it
+    must render promptly even when the dashboard is slow or unreachable
+    rather than hanging for as long as a real request would.
+    """
+    try:
+        version = await asyncio.wait_for(get_client().get_version(), timeout=_STATUS_CHECK_TIMEOUT)
+        return f"connected (ESPHome {escape(version)})"
+    except TimeoutError:
+        return f"unreachable (timed out after {_STATUS_CHECK_TIMEOUT:.0f}s)"
+    except Exception as e:
+        return f"unreachable ({escape(str(e))})"
+
+
+@mcp.custom_route("/", methods=["GET"])
+async def status_page(request: Request) -> Response:
+    """Ingress-served status page: dashboard connectivity + MCP connect instructions.
+
+    Not the MCP endpoint itself (that's mounted separately, at MCP_PATH) — HA
+    ingress requires an authenticated HA session, which most MCP clients can't do.
+    Safe to show the live secret path here precisely because ingress *is*
+    authenticated, unlike add-on logs.
+    """
+    dashboard_status = await _check_dashboard_status()
+    port = await _resolve_host_port()
+    mcp_path = escape(os.environ.get("MCP_PATH", "/mcp"))
+
+    html = f"""<!doctype html>
+<html>
+<head><title>ESPHome MCP</title></head>
+<body>
+<h1>ESPHome MCP</h1>
+<p>Dashboard: {dashboard_status}</p>
+<h2>Connect your MCP client</h2>
+<pre>http://&lt;your-home-assistant-ip-or-hostname&gt;:{port}{mcp_path}</pre>
+<p>Replace <code>&lt;your-home-assistant-ip-or-hostname&gt;</code> with the address
+you use to reach Home Assistant itself (same host, without the :8123) &mdash; this
+add-on listens on a separate port from the main HA web UI.</p>
+</body>
+</html>"""
+    return HTMLResponse(html)
 
 
 async def _resolve_device(device_name: str) -> dict[str, Any] | str:

--- a/tests/test_addon.py
+++ b/tests/test_addon.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from esphome_mcp import addon
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _isolated_environ():
+    """Restore os.environ after every test.
+
+    apply_addon_options_to_env / resolve_mcp_path mutate os.environ directly
+    (that's their job) via os.environ[...] = ..., which monkeypatch.setenv/delenv
+    can't track or auto-revert since it never made those calls itself. Without
+    this, a test setting ESPHOME_DASHBOARD_URL leaks it into every later test in
+    the whole suite (including the live-dashboard test, which then tries to
+    actually connect to it).
+    """
+    original = dict(os.environ)
+    yield
+    os.environ.clear()
+    os.environ.update(original)
+
+
+# ------------------------------------------------------------------ load_addon_options
+
+
+def test_load_addon_options_missing_file(tmp_path: Path):
+    assert addon.load_addon_options(tmp_path / "options.json") == {}
+
+
+def test_load_addon_options_malformed_json(tmp_path: Path):
+    options_path = tmp_path / "options.json"
+    options_path.write_text("{not valid json")
+    assert addon.load_addon_options(options_path) == {}
+
+
+def test_load_addon_options_valid(tmp_path: Path):
+    options_path = tmp_path / "options.json"
+    options_path.write_text(json.dumps({"dashboard_url": "http://esphome.local"}))
+    assert addon.load_addon_options(options_path) == {"dashboard_url": "http://esphome.local"}
+
+
+# ------------------------------------------------------------- apply_addon_options_to_env
+
+
+def test_apply_addon_options_to_env_sets_unset_vars(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("ESPHOME_DASHBOARD_URL", raising=False)
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    addon.apply_addon_options_to_env(
+        {"dashboard_url": "http://esphome.local", "log_level": "debug"}
+    )
+    import os
+
+    assert os.environ["ESPHOME_DASHBOARD_URL"] == "http://esphome.local"
+    assert os.environ["LOG_LEVEL"] == "debug"
+
+
+def test_apply_addon_options_to_env_explicit_env_wins(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ESPHOME_DASHBOARD_URL", "http://explicit.example.com")
+    addon.apply_addon_options_to_env({"dashboard_url": "http://from-options.local"})
+    import os
+
+    assert os.environ["ESPHOME_DASHBOARD_URL"] == "http://explicit.example.com"
+
+
+def test_apply_addon_options_to_env_skips_empty_values(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("ESPHOME_DASHBOARD_USERNAME", raising=False)
+    addon.apply_addon_options_to_env({"dashboard_username": ""})
+    import os
+
+    assert "ESPHOME_DASHBOARD_USERNAME" not in os.environ
+
+
+# --------------------------------------------------------------- get_or_create_secret_path
+
+
+def test_get_or_create_secret_path_generates_when_absent(tmp_path: Path):
+    secret_file = tmp_path / "secret_path.txt"
+    path = addon.get_or_create_secret_path({}, secret_file)
+    assert path.startswith("/private_")
+    assert len(path) >= 8
+    assert secret_file.read_text().strip() == path
+
+
+def test_get_or_create_secret_path_reuses_existing_valid(tmp_path: Path):
+    secret_file = tmp_path / "secret_path.txt"
+    secret_file.write_text("/private_existingtoken123")
+    path = addon.get_or_create_secret_path({}, secret_file)
+    assert path == "/private_existingtoken123"
+
+
+def test_get_or_create_secret_path_regenerates_when_stored_invalid(tmp_path: Path):
+    secret_file = tmp_path / "secret_path.txt"
+    secret_file.write_text("short")
+    path = addon.get_or_create_secret_path({}, secret_file)
+    assert path != "short"
+    assert path.startswith("/private_")
+    assert secret_file.read_text().strip() == path
+
+
+def test_get_or_create_secret_path_honors_valid_override(tmp_path: Path):
+    secret_file = tmp_path / "secret_path.txt"
+    path = addon.get_or_create_secret_path({"secret_path": "/my-custom-path"}, secret_file)
+    assert path == "/my-custom-path"
+    assert secret_file.read_text().strip() == "/my-custom-path"
+
+
+def test_get_or_create_secret_path_override_without_leading_slash(tmp_path: Path):
+    secret_file = tmp_path / "secret_path.txt"
+    path = addon.get_or_create_secret_path({"secret_path": "my-custom-path"}, secret_file)
+    assert path == "/my-custom-path"
+
+
+def test_get_or_create_secret_path_invalid_override_falls_back(tmp_path: Path):
+    secret_file = tmp_path / "secret_path.txt"
+    secret_file.write_text("/private_storedvalid1234")
+    path = addon.get_or_create_secret_path({"secret_path": "/x"}, secret_file)
+    assert path == "/private_storedvalid1234"
+
+
+def test_get_or_create_secret_path_two_calls_are_stable(tmp_path: Path):
+    secret_file = tmp_path / "secret_path.txt"
+    first = addon.get_or_create_secret_path({}, secret_file)
+    second = addon.get_or_create_secret_path({}, secret_file)
+    assert first == second
+
+
+def test_get_or_create_secret_path_regenerate_forces_new_value(tmp_path: Path):
+    secret_file = tmp_path / "secret_path.txt"
+    secret_file.write_text("/private_originalvalid123")
+
+    new = addon.get_or_create_secret_path({"regenerate_secret_path": True}, secret_file)
+
+    assert new != "/private_originalvalid123"
+    assert new.startswith("/private_")
+    assert secret_file.read_text().strip() == new
+
+
+def test_get_or_create_secret_path_override_wins_over_regenerate(tmp_path: Path):
+    secret_file = tmp_path / "secret_path.txt"
+    path = addon.get_or_create_secret_path(
+        {"regenerate_secret_path": True, "secret_path": "/my-pinned-path"}, secret_file
+    )
+    assert path == "/my-pinned-path"
+
+
+def test_get_or_create_secret_path_regenerate_resets_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    secret_file = tmp_path / "secret_path.txt"
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        addon, "_reset_regenerate_flag", lambda options, client=None: calls.append(options)
+    )
+
+    addon.get_or_create_secret_path({"regenerate_secret_path": True}, secret_file)
+
+    assert len(calls) == 1
+    assert calls[0]["regenerate_secret_path"] is True
+
+
+def test_get_or_create_secret_path_no_regenerate_does_not_reset_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    secret_file = tmp_path / "secret_path.txt"
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        addon, "_reset_regenerate_flag", lambda options, client=None: calls.append(options)
+    )
+
+    addon.get_or_create_secret_path({}, secret_file)
+
+    assert calls == []
+
+
+def test_reset_regenerate_flag_posts_options_with_flag_off(monkeypatch: pytest.MonkeyPatch):
+    import httpx
+
+    monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+    posted: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["authorization"] == "Bearer test-token"
+        posted.update(json.loads(request.content))
+        return httpx.Response(200, json={"result": "ok"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    addon._reset_regenerate_flag({"regenerate_secret_path": True, "log_level": "info"}, client)
+
+    assert posted == {"options": {"regenerate_secret_path": False, "log_level": "info"}}
+
+
+def test_reset_regenerate_flag_no_token_is_noop(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+    # Must not raise even without a client / token.
+    addon._reset_regenerate_flag({"regenerate_secret_path": True})
+
+
+def test_reset_regenerate_flag_swallows_http_errors(monkeypatch: pytest.MonkeyPatch):
+    import httpx
+
+    monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    # Must not raise.
+    addon._reset_regenerate_flag({"regenerate_secret_path": True}, client)
+
+
+# ------------------------------------------------------------------------ resolve_mcp_path
+
+
+def test_resolve_mcp_path_no_options_file_defaults_to_mcp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.delenv("MCP_PATH", raising=False)
+    result = addon.resolve_mcp_path(
+        options_path=tmp_path / "missing.json", secret_file=tmp_path / "secret_path.txt"
+    )
+    assert result == "/mcp"
+    assert not (tmp_path / "secret_path.txt").exists()
+
+
+def test_resolve_mcp_path_no_options_file_honors_explicit_mcp_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("MCP_PATH", "/custom")
+    result = addon.resolve_mcp_path(
+        options_path=tmp_path / "missing.json", secret_file=tmp_path / "secret_path.txt"
+    )
+    assert result == "/custom"
+
+
+def test_resolve_mcp_path_with_options_sets_secret_path_and_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.delenv("MCP_PATH", raising=False)
+    monkeypatch.delenv("ESPHOME_DASHBOARD_URL", raising=False)
+    options_path = tmp_path / "options.json"
+    options_path.write_text(json.dumps({"dashboard_url": "http://esphome.local"}))
+    secret_file = tmp_path / "secret_path.txt"
+
+    import os
+
+    result = addon.resolve_mcp_path(options_path=options_path, secret_file=secret_file)
+
+    assert result.startswith("/private_")
+    assert os.environ["MCP_PATH"] == result
+    assert os.environ["ESPHOME_DASHBOARD_URL"] == "http://esphome.local"
+    assert secret_file.exists()
+
+
+def test_resolve_mcp_path_with_options_explicit_mcp_path_wins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("MCP_PATH", "/already-set")
+    options_path = tmp_path / "options.json"
+    options_path.write_text(json.dumps({"dashboard_url": "http://esphome.local"}))
+    secret_file = tmp_path / "secret_path.txt"
+
+    result = addon.resolve_mcp_path(options_path=options_path, secret_file=secret_file)
+
+    assert result == "/already-set"
+    assert not secret_file.exists()

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+_HEALTHCHECK_PATH = Path(__file__).resolve().parent.parent / "healthcheck.py"
+
+
+def _load_healthcheck():
+    spec = importlib.util.spec_from_file_location("healthcheck", _HEALTHCHECK_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["healthcheck"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_mcp_url_defaults_to_mcp(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("MCP_PATH", raising=False)
+    healthcheck = _load_healthcheck()
+    assert healthcheck._mcp_url() == "http://localhost:8080/mcp"
+
+
+def test_mcp_url_honors_mcp_path_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MCP_PATH", "/private_abc123")
+    healthcheck = _load_healthcheck()
+    assert healthcheck._mcp_url() == "http://localhost:8080/private_abc123"

--- a/tests/test_main_web.py
+++ b/tests/test_main_web.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from esphome_mcp import __main__ as main_module
+
+
+def test_main_web_passes_resolved_path_to_mcp_run(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(main_module.addon, "resolve_mcp_path", lambda: "/private_abc123")
+    monkeypatch.setattr(main_module, "_configure_logging", lambda: None)
+    monkeypatch.setattr(main_module, "_check_connectivity_background", lambda: None)
+    run_mock = MagicMock()
+    monkeypatch.setattr(main_module.mcp, "run", run_mock)
+
+    main_module.main_web()
+
+    run_mock.assert_called_once_with(
+        transport="http", host="0.0.0.0", port=8080, path="/private_abc123"
+    )
+
+
+def test_main_web_defaults_path_to_mcp(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(main_module.addon, "resolve_mcp_path", lambda: "/mcp")
+    monkeypatch.setattr(main_module, "_configure_logging", lambda: None)
+    monkeypatch.setattr(main_module, "_check_connectivity_background", lambda: None)
+    run_mock = MagicMock()
+    monkeypatch.setattr(main_module.mcp, "run", run_mock)
+
+    main_module.main_web()
+
+    run_mock.assert_called_once_with(transport="http", host="0.0.0.0", port=8080, path="/mcp")
+
+
+def test_main_web_configures_logging_before_resolving_mcp_path(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression test: logging must be configured before resolve_mcp_path() runs,
+    or any INFO/WARNING it logs (options merge, secret-path resolution) is
+    silently dropped by Python's no-handler-yet fallback — as happened on a real
+    HA instance, where a failed discovery attempt left zero trace in the logs."""
+    call_order: list[str] = []
+    monkeypatch.setattr(
+        main_module.addon,
+        "resolve_mcp_path",
+        lambda: call_order.append("resolve_mcp_path") or "/mcp",
+    )
+    monkeypatch.setattr(
+        main_module, "_configure_logging", lambda: call_order.append("_configure_logging")
+    )
+    monkeypatch.setattr(main_module, "_check_connectivity_background", lambda: None)
+    monkeypatch.setattr(main_module.mcp, "run", MagicMock())
+
+    main_module.main_web()
+
+    assert call_order.index("_configure_logging") < call_order.index("resolve_mcp_path")
+
+
+def test_main_web_starts_server_without_waiting_on_connectivity_check(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression test: the HTTP server (and the add-on's ingress status page)
+    must come up immediately, not after the connectivity check finishes --
+    otherwise a user whose dashboard is unreachable can't see *why* until the
+    whole retry window elapses (or, before an earlier fix, ever). Verified live
+    on a real HA instance."""
+    monkeypatch.setattr(main_module.addon, "resolve_mcp_path", lambda: "/mcp")
+    monkeypatch.setattr(main_module, "_configure_logging", lambda: None)
+
+    call_order: list[str] = []
+    monkeypatch.setattr(
+        main_module,
+        "_check_connectivity_background",
+        lambda: call_order.append("_check_connectivity_background"),
+    )
+    monkeypatch.setattr(
+        main_module.mcp, "run", MagicMock(side_effect=lambda **kw: call_order.append("mcp.run"))
+    )
+
+    main_module.main_web()
+
+    assert call_order == ["_check_connectivity_background", "mcp.run"]
+
+
+def test_check_connectivity_background_spawns_daemon_thread_non_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    received: list[bool] = []
+    done = threading.Event()
+
+    def fake_check_connectivity(fatal: bool = True) -> None:
+        received.append(fatal)
+        done.set()
+
+    monkeypatch.setattr(main_module, "_check_connectivity", fake_check_connectivity)
+
+    main_module._check_connectivity_background()
+
+    assert done.wait(timeout=2), "background thread never ran _check_connectivity"
+    assert received == [False]
+
+
+def test_check_connectivity_fatal_raises_after_exhausting_retries(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(main_module, "_RETRY_DELAY", 0)
+    monkeypatch.setattr(main_module, "_MAX_RETRIES", 1)
+
+    class _FakeClient:
+        async def get_version(self) -> str:
+            raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(main_module, "get_client", lambda: _FakeClient())
+
+    with pytest.raises(SystemExit):
+        main_module._check_connectivity(fatal=True)
+
+
+def test_check_connectivity_non_fatal_returns_after_exhausting_retries(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(main_module, "_RETRY_DELAY", 0)
+    monkeypatch.setattr(main_module, "_MAX_RETRIES", 1)
+
+    class _FakeClient:
+        async def get_version(self) -> str:
+            raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(main_module, "get_client", lambda: _FakeClient())
+
+    main_module._check_connectivity(fatal=False)  # must not raise

--- a/tests/test_server_status.py
+++ b/tests/test_server_status.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+from starlette.testclient import TestClient
+
+from esphome_mcp import server
+
+if TYPE_CHECKING:
+    import pytest
+
+# ------------------------------------------------------------------- _resolve_host_port
+
+
+async def test_resolve_host_port_no_token(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+    assert await server._resolve_host_port() == server.DEFAULT_PORT
+
+
+async def test_resolve_host_port_success(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["authorization"] == "Bearer test-token"
+        return httpx.Response(200, json={"data": {"network": {"8080/tcp": 9999}}})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    assert await server._resolve_host_port(client) == 9999
+
+
+async def test_resolve_host_port_falls_back_on_http_error(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    assert await server._resolve_host_port(client) == server.DEFAULT_PORT
+
+
+async def test_resolve_host_port_falls_back_on_malformed_response(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": {}})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    assert await server._resolve_host_port(client) == server.DEFAULT_PORT
+
+
+# --------------------------------------------------------------- _check_dashboard_status
+
+
+class _SlowClient:
+    """Simulates a dashboard call that hangs past the status page's own timeout."""
+
+    async def get_version(self) -> str:
+        await asyncio.sleep(10)
+        return "unreachable-in-practice"
+
+
+async def test_check_dashboard_status_times_out_quickly(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(server, "get_client", lambda: _SlowClient())
+    monkeypatch.setattr(server, "_STATUS_CHECK_TIMEOUT", 0.05)
+
+    start = time.monotonic()
+    result = await server._check_dashboard_status()
+    elapsed = time.monotonic() - start
+
+    assert "unreachable" in result.lower()
+    assert "timed out" in result.lower()
+    assert elapsed < 1.0
+
+
+# ------------------------------------------------------------------------- status_page
+
+
+class _FakeClient:
+    def __init__(self, version: str = "2026.6.0", error: Exception | None = None) -> None:
+        self._version = version
+        self._error = error
+
+    async def get_version(self) -> str:
+        if self._error:
+            raise self._error
+        return self._version
+
+
+async def _fake_port() -> int:
+    return 8080
+
+
+def test_status_page_healthy(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(server, "get_client", lambda: _FakeClient())
+    monkeypatch.setattr(server, "_resolve_host_port", _fake_port)
+    monkeypatch.setenv("MCP_PATH", "/private_abc123")
+
+    client = TestClient(server.mcp.http_app())
+    resp = client.get("/")
+
+    assert resp.status_code == 200
+    assert "2026.6.0" in resp.text
+    assert "/private_abc123" in resp.text
+    assert ":8080" in resp.text
+
+
+def test_status_page_dashboard_unreachable(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        server, "get_client", lambda: _FakeClient(error=RuntimeError("connection refused"))
+    )
+    monkeypatch.setattr(server, "_resolve_host_port", _fake_port)
+    monkeypatch.setenv("MCP_PATH", "/private_abc123")
+
+    client = TestClient(server.mcp.http_app())
+    resp = client.get("/")
+
+    assert resp.status_code == 200
+    assert "unreachable" in resp.text.lower()
+    assert "connection refused" in resp.text
+
+
+def test_status_page_defaults_mcp_path_when_unset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(server, "get_client", lambda: _FakeClient())
+    monkeypatch.setattr(server, "_resolve_host_port", _fake_port)
+    monkeypatch.delenv("MCP_PATH", raising=False)
+
+    client = TestClient(server.mcp.http_app())
+    resp = client.get("/")
+
+    assert "/mcp" in resp.text


### PR DESCRIPTION
Closes #1

## Summary

- Packages this repo as an installable Home Assistant Supervisor add-on (`repository.yaml` + `ha_addon/esphome-mcp/`), reusing the existing multi-arch image published by CI — no new Dockerfile, no separate build.
- Secures the MCP endpoint with a persisted, high-entropy secret URL path (`/private_<token>`) instead of a fixed `/mcp`, generated on first run and regenerable via a `regenerate_secret_path` option — matches the model used by [homeassistant-ai/ha-mcp](https://github.com/homeassistant-ai/ha-mcp).
- Adds an ingress-served status page (dashboard connectivity + the live MCP connect URL) — kept separate from the MCP endpoint itself since ingress requires an authenticated HA session that MCP clients can't provide.
- `dashboard_url` defaults to `http://homeassistant.local:6052`, correct out of the box when the official ESPHome Device Builder add-on runs on the same host. Real auto-discovery was attempted and reverted: HA Supervisor's discovery API (`GET /discovery`) is Home Assistant Core-only and not callable by other add-ons at any role — confirmed against Supervisor's own source and live testing.
- Plain `docker compose` usage is unaffected — every add-on-specific code path is gated on `/data/options.json` existing, which is absent outside the add-on.

## Notable fixes found via live testing against a real HA instance

- HTTP server startup no longer blocks on (or exits over) the dashboard connectivity pre-flight check — it now runs in a background thread so the ingress status page and Docker `HEALTHCHECK` can report "dashboard unreachable" instead of nothing being reachable at all.
- The status page's own connectivity check has a short (5s) timeout independent of the app's general 30s timeout, so it renders promptly as a diagnostic rather than hanging.

## Test plan

- [x] `ruff check` / `ruff format --check` / `ty check` / `pytest` all pass (47 passed, 1 skipped — the live-dashboard test, which needs a real `ESPHOME_DASHBOARD_URL`)
- [x] Live-verified on a real Home Assistant OS instance: repository add, install, start, options merge, secret-path generation/regeneration, ingress status page, port remapping via the Network tab, and the connectivity-blocking fix
